### PR TITLE
Removing dead code leading to warnings

### DIFF
--- a/src/lib/doc.rs
+++ b/src/lib/doc.rs
@@ -33,8 +33,7 @@ impl ToPyObject for Doc {
   fn to_py_object(&self, python: Python)
     -> PyObject {
       let doc = match Some((self.object).as_ref().unwrap()) {
-        val => val.to_py_object(python).into_object(),
-        None => python.None(),
+        val => val.to_py_object(python).into_object()
       };
       doc.clone_ref(python)
     }
@@ -61,9 +60,9 @@ impl<T: ToPyObject> dispatch::Call<T> where T: Callable<PyObject> {
       self
     }
   
-  pub fn kwargs(mut self, kwargs: &'static str)
+  pub fn kwargs(mut self, kwargs: Option<&'static str>)
     -> Self {
-      self.kwargs = kwargs;
+      self.kwargs = kwargs.unwrap_or("");
       self
     }
     

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,6 @@ fn main() {
   pangram1
     .call("similarity")
     .args(pangram2)
-    .kwargs("")
+    .kwargs(None)
     .invoke();
 }


### PR DESCRIPTION
Finally removing code that lead to warnings, mainly a dead path to `None`, when it seems that `PyObject` already encompasses `None`.